### PR TITLE
Leaver user’s PATH untouched.

### DIFF
--- a/bin/qfc.sh
+++ b/bin/qfc.sh
@@ -17,8 +17,14 @@ function get_cursor_position(){
   echo "$row $col"
 }
 
-if [[ -d ~/.qfc/ ]]; then
-    export PATH=~/.qfc/bin:"${PATH}"
+# Determine the absolute path to the QFC script.
+if [[ -n "$BASH_VERSION" ]]; then
+  # Bash doesn’t evaluate $0 the right way when the script is sourced;
+  # use $BASH_SOURCE instead.
+  QFC=$(realpath $(dirname ${BASH_SOURCE[0]}))/qfc
+else
+  # In zsh, $0 is consistent between sourcing and script invocation.
+  QFC=$(realpath $(dirname $0))/qfc
 fi
 
 if [[ -n "$ZSH_VERSION" ]]; then
@@ -38,7 +44,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
 
         # instruct qfc to store the result (completion path) into a temporary file
         tmp_file=$(mktemp -t qfc.XXXXXXX)
-        </dev/tty qfc --search="$word" --stdout="$tmp_file"
+        </dev/tty "$QFC" --search="$word" --stdout="$tmp_file"
         result=$(<$tmp_file)
         rm -f $tmp_file
         
@@ -86,7 +92,7 @@ elif [[ -n "$BASH" ]]; then
         word=${word##* }
 
         tmp_file=$(mktemp -t qfc.XXXXXXX)
-        </dev/tty qfc --search="$word" --stdout="$tmp_file"
+        </dev/tty "$QFC" --search="$word" --stdout="$tmp_file"
         result=$(<$tmp_file)
         rm -f $tmp_file
 


### PR DESCRIPTION
Instead of adding the location of qfc to the user’s PATH, this
leaves PATH untouched and calls qfc at an arbitrary install
location instead.

In addition to not adding noise to the user’s path for just one
script, this also allows having qfc installed to a location other
than ~/.qfc.